### PR TITLE
Build faster executable using cx_freeze

### DIFF
--- a/src/engine/engine_build_fast.sh
+++ b/src/engine/engine_build_fast.sh
@@ -1,0 +1,13 @@
+# Use cx_freeze to build a faster executable of pvengine
+
+# Delete current pvengine executable
+rm pvengine
+rm build/pvengine
+
+cxfreeze -c engine_main.py --target-dir=build --target-name=pvengine
+
+# Delete frozen_application_license.txt
+rm build/frozen_application_license.txt
+
+# First startup is slow, so we run the executable once to activate it
+echo "quit" | build/pvengine

--- a/src/engine/engine_search.py
+++ b/src/engine/engine_search.py
@@ -64,7 +64,7 @@ def search(rootPos: chess.Board, MAX_MOVES=5, MAX_ITERS=100, depth: int = None, 
     # If we likely don't have enough time to search all moves, only use root engine eval
     if useTimeMan:
         if rootMovesSize * default_nodes > optTime / 1000 * lastNps:
-            info: chess.engine.InfoDict = engine_engine.__engine__(fen=rootPos.fen(), time=optTime)
+            info: chess.engine.InfoDict = engine_engine.__engine__(fen=rootPos.fen(), time=optTime / 1000)
             score = Value(info["score"])
             bestPv = info["pv"]
             bestMove = bestPv[0]


### PR DESCRIPTION
Build script: engine_build_fast.sh
Requires dependency: cx_Freeze (python package)

After the first 'activation' run, the executable now starts almost instantly.

Also fix a timeman bug if we likely don't have enough time for depth 1 (forgot to convert ms to s).