### PR TITLE
v4.0.1: Fix illegal moves; Make nps a running average

### DIFF
--- a/src/engine/engine_search.py
+++ b/src/engine/engine_search.py
@@ -404,7 +404,7 @@ def search(rootPos: chess.Board, MAX_MOVES=GET_MAX_MOVES(), MAX_ITERS=GET_MAX_DE
     
     # After search is finished
     bestPv = rootMovesPv[bestMove]
-    if len(bestPv) == 1:
+    if len(bestPv) <= 1:
         printf(f"bestmove {bestMove}")
     else:
         printf(f"bestmove {bestMove} ponder {bestPv[1]}")

--- a/src/engine/engine_search.py
+++ b/src/engine/engine_search.py
@@ -356,10 +356,10 @@ def search(rootPos: chess.Board, MAX_MOVES=GET_MAX_MOVES(), MAX_ITERS=GET_MAX_DE
                 rootMovesExtraNodes[bestMove] += 0.1
         
         # Allow re-calculation of move PVs
-        if (rootMovesSize <= 1 and i - prevRecalcIter >= recalcCount - 1) or \
-            (rootMovesSize / len(rootMoves) <= 0.2 or
-            (bestValue - prevBestValue <= -(25 + i / 2) or bestValue - rootScore <= -(50 + i))) \
-                and i - prevRecalcIter >= 5 + 2 * recalcCount:
+        if ( (rootMovesSize <= 1 and i - prevRecalcIter >= recalcCount - 1) or
+             rootMovesSize / len(rootMoves) <= max(0.02, 0.2 - recalcCount * 0.02) or
+             bestValue - prevBestValue <= -(25 + i / 2) or (i <= 10 and bestValue - rootScore <= -(50 + i)) ) \
+            and i - prevRecalcIter >= 5 + 2 * recalcCount:
             # Every move needs to be re-calculated
             nextIterRecalcMoves = rootMoves.copy()
         
@@ -395,6 +395,7 @@ def search(rootPos: chess.Board, MAX_MOVES=GET_MAX_MOVES(), MAX_ITERS=GET_MAX_DE
             bestValue = Value(-VALUE_INFINITE, rootStm)
             prevRecalcIter = i
             recalcCount += 1
+            nextIterRecalcMoves = []
 
         prevBestValue = bestValue
         prevBestMove = bestMove

--- a/src/engine/engine_search_h.py
+++ b/src/engine/engine_search_h.py
@@ -120,6 +120,32 @@ class Value:
         return Value(self.value, pov)
 
 
+class RunningAverage:
+    max_count = 1024
+    total = 0
+    count = 0
+    earliest = 0
+    
+    def __init__(self, max_count=1024):
+        self.max_count = max_count
+    
+    def add(self, value):
+        self.total += value
+        self.count += 1
+        if self.count > self.max_count:
+            self.total -= self.earliest
+            self.count -= 1
+    
+    def value(self):
+        return self.total / self.count if self.count > 0 else 0
+
+    def __str__(self):
+        return str(self.value())
+    
+    def __int__(self):
+        return int(self.value())
+    
+    
 def clamp(value, min_value, max_value):
     return max(min(value, max_value), min_value)
 

--- a/src/engine/engine_uci.py
+++ b/src/engine/engine_uci.py
@@ -1,7 +1,7 @@
 """
 Special thanks to PyFish for most of the UCI code.
 """
-ENGINE_VERSION = "v4.0.0"
+ENGINE_VERSION = "v4.0.1"
 ENGINE_NAME = "PVengine"
 ENGINE_AUTHOR = "J Muzhen"
 

--- a/src/engine/engine_utils.py
+++ b/src/engine/engine_utils.py
@@ -6,7 +6,8 @@ import chess.engine
 from engine_ucioption import *
 
 
-def push_pv(board: chess.Board, pv, info=None, is_tb=False):
+def push_pv(pos: chess.Board, pv, info=None, is_tb=False):
+    board = pos.copy()
     if type(pv) == str:
         pv = pv.split('pv')[-1]
         pv = pv.split()


### PR DESCRIPTION
1. Fix rootMovesPos not being updated with the correct PV;
2. Make nps a running average of the last 5 iterations. The effect of this is much shallower search at low depths (due to lower nps at low depths), while a much greater change is observed at around depth=7.

fixes #11 